### PR TITLE
Use relative link to register web+comit protocol handler

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,11 +30,7 @@ const appTheme = createMuiTheme({
 
 install();
 
-navigator.registerProtocolHandler(
-  "web+comit",
-  "http://localhost:3000/from_link?%s",
-  "COMIT-i"
-);
+navigator.registerProtocolHandler("web+comit", "/from_link?%s", "COMIT-i");
 
 ReactDOM.render(
   <ThemeProvider theme={appTheme}>


### PR DESCRIPTION
This decouples the application from where it is hosted. The browser fill will in the rest, like localhost:3000 if the app is hosted on localhost:3000.