### PR TITLE
Make links clickable on some applications

### DIFF
--- a/src/pages/LinkLandingPage/parseQuery.spec.ts
+++ b/src/pages/LinkLandingPage/parseQuery.spec.ts
@@ -3,7 +3,7 @@ import parseQuery from "./parseQuery";
 describe("parseQuery", () => {
   it("should parse the link given by the protocol handler", () => {
     const query =
-      "?web%2Bcomit%3Aswap%3Falpha_ledger%3Dbitcoin%26beta_ledger%3Dethereum%26alpha_asset%3D1.5BTC%26beta_asset%3D420ERC20%3A0xB97048628DB6B661D4C2aA833e95Dbe1A905B280%26protocol%3Drfc003%26peer%3DQma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi";
+      "?web%2Bcomit%3A%2F%2Fswap%3Falpha_ledger%3Dbitcoin%26beta_ledger%3Dethereum%26alpha_asset%3D1.5BTC%26beta_asset%3D420ERC20%3A0xB97048628DB6B661D4C2aA833e95Dbe1A905B280%26protocol%3Drfc003%26peer%3DQma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi";
 
     const result = parseQuery(query);
 
@@ -19,7 +19,7 @@ describe("parseQuery", () => {
 
   it("should link with duplicated keys", () => {
     const query =
-      "?web%2Bcomit%3Aswap%3Falpha_ledger%3Dbitcoin%26alpha_ledger%3Dbitcoin%26beta_ledger%3Dethereum%26alpha_asset%3D1.5BTC%26beta_asset%3D420ERC20%3A0xB97048628DB6B661D4C2aA833e95Dbe1A905B280%26protocol%3Drfc003%26peer%3DQma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi";
+      "?web%2Bcomit%3A%2F%2Fswap%3Falpha_ledger%3Dbitcoin%26alpha_ledger%3Dbitcoin%26beta_ledger%3Dethereum%26alpha_asset%3D1.5BTC%26beta_asset%3D420ERC20%3A0xB97048628DB6B661D4C2aA833e95Dbe1A905B280%26protocol%3Drfc003%26peer%3DQma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi";
 
     const result = parseQuery(query);
 

--- a/src/pages/LinkLandingPage/parseQuery.ts
+++ b/src/pages/LinkLandingPage/parseQuery.ts
@@ -19,14 +19,15 @@ function firstOrValue(value: string | string[]) {
 }
 
 export default function parseQuery(query: string): QueryParams {
-  const normalizedQuery = URI.decodeQuery(query).replace("web+comit:swap", "");
+  const queryString = query.replace("?", "");
+  const normalizedQuery = URI.decodeQuery(queryString);
+  const link = new URI(normalizedQuery);
+  const linkQuery = URI.parseQuery(link.query());
 
-  const parsedQuery = URI.parseQuery(normalizedQuery);
-
-  return Object.keys(parsedQuery)
+  return Object.keys(linkQuery)
     .map(key => {
       // @ts-ignore
-      const value = parsedQuery[key];
+      const value = linkQuery[key];
 
       return {
         [key]: firstOrValue(value)

--- a/src/pages/LinkLandingPage/parseQuery.ts
+++ b/src/pages/LinkLandingPage/parseQuery.ts
@@ -19,7 +19,8 @@ function firstOrValue(value: string | string[]) {
 }
 
 export default function parseQuery(query: string): QueryParams {
-  const queryString = query.replace("?", "");
+  const queryString = query.charAt(0) === "?" ? query.substr(1) : query;
+
   const normalizedQuery = URI.decodeQuery(queryString);
   const link = new URI(normalizedQuery);
   const linkQuery = URI.parseQuery(link.query());

--- a/src/pages/MakeLink/MakeLink.tsx
+++ b/src/pages/MakeLink/MakeLink.tsx
@@ -20,7 +20,10 @@ const MakeLink = () => {
   const [protocol, setProtocol] = useState("");
   const [peer, setPeer] = useState("");
 
-  let uri = URI("web+comit:swap");
+  let uri = new URI({
+    protocol: "web+comit",
+    hostname: "swap"
+  });
 
   const alphaLedgerQueryValue = ledgerToQueryValue(swap.alpha_ledger);
   if (alphaLedgerQueryValue) {


### PR DESCRIPTION
Applications such as WhatsApp and Slack will now display swap links as clickable links. The only tradeoff is that `swap` has been moved from the path to the authority.

Resolves #34.