### PR TITLE
Ensure comit-i works with comit-rs

### DIFF
--- a/cypress/integration/sendSwapRequest.spec.ts
+++ b/cypress/integration/sendSwapRequest.spec.ts
@@ -70,7 +70,7 @@ describe("The page for sending a swap request", () => {
       cy.get("[data-cy=peer-input]")
         .find("input")
         .clear()
-        .type("0.0.0.0:8011");
+        .type("QmPRNaiDUcJmnuJWUyoADoqvFotwaMRFKV2RyZ7ZVr1fqd");
     });
 
     it("should display an error if form is submitted without connection to a comit node", () => {

--- a/src/pages/ListSwaps/SwapRow.tsx
+++ b/src/pages/ListSwaps/SwapRow.tsx
@@ -147,6 +147,7 @@ function SwapRow(swap: Swap) {
         setDialogState(DialogState.CommunicationDialogOpen);
         break;
       case "fund":
+      case "deploy":
       case "redeem":
       case "refund":
         const params = actionQueryParams(swap, name);

--- a/src/pages/SendSwapRequest/SendSwapRequest.tsx
+++ b/src/pages/SendSwapRequest/SendSwapRequest.tsx
@@ -23,7 +23,9 @@ const SendSwap = ({ location, history }: RouteComponentProps) => {
   const [swap, dispatch] = useReducer(swapReducer, emptySwap);
 
   const [params, setParams] = useState<Rfc003Params>(defaultRfc003Params);
-  const [peer, setPeer] = useState("0.0.0.0:8011");
+  const [peer, setPeer] = useState(
+    "QmPRNaiDUcJmnuJWUyoADoqvFotwaMRFKV2RyZ7ZVr1fqd"
+  );
   const [displayError, setDisplayError] = useState(false);
 
   const queryParams = URI.parseQuery(location.search) as {

--- a/src/pages/SendSwapRequest/SendSwapRequest.tsx
+++ b/src/pages/SendSwapRequest/SendSwapRequest.tsx
@@ -76,7 +76,7 @@ const SendSwap = ({ location, history }: RouteComponentProps) => {
                   value={peer}
                   onChange={event => setPeer(event.target.value)}
                   label={"Peer"}
-                  helperText={"IPv4 Socket Address"}
+                  helperText={"Peer id"}
                   data-cy="peer-input"
                 />
               </Fieldset>


### PR DESCRIPTION
Nothing had to be changed for BTC<->ETH swaps to work. In the case of ERC20, the deploy action is now clickable and works. It remains to be tested all the way, as the parity image used does not have a token contract.

Fixes #46.