### PR TITLE
Reset RFC003 params field when ledger changes

### DIFF
--- a/src/forms/Rfc003ParamsForm.tsx
+++ b/src/forms/Rfc003ParamsForm.tsx
@@ -32,11 +32,17 @@ export const defaultRfc003Params: Rfc003Params = {
   beta_ledger_redeem_identity: undefined
 };
 
-export function resetParams(currentParams: Rfc003Params) {
+export function resetAlphaIdentity(currentParams: Rfc003Params) {
   return {
     ...currentParams,
     alpha_ledger_refund_identity:
-      defaultRfc003Params.alpha_ledger_refund_identity,
+      defaultRfc003Params.alpha_ledger_refund_identity
+  };
+}
+
+export function resetBetaIdentity(currentParams: Rfc003Params) {
+  return {
+    ...currentParams,
     beta_ledger_redeem_identity: defaultRfc003Params.beta_ledger_redeem_identity
   };
 }

--- a/src/forms/SwapForm.tsx
+++ b/src/forms/SwapForm.tsx
@@ -124,8 +124,8 @@ function SwapForm({
   swap,
   ledgers,
   dispatch,
-  onAlphaLedgerChange,
-  onBetaLedgerChange,
+  onAlphaLedgerChange = () => undefined,
+  onBetaLedgerChange = () => undefined,
   disabled = false
 }: Props) {
   const alphaLedger = swap.alpha_ledger;
@@ -155,7 +155,7 @@ function SwapForm({
     label: asset.label
   }));
 
-  const onSelectionChange = (of: keyof Swap, callback?: () => void) => (
+  const onSelectionChange = (of: keyof Swap, callback: () => void) => (
     selection: string
   ) => {
     dispatch({
@@ -163,9 +163,7 @@ function SwapForm({
       of,
       payload: { newSelection: selection }
     });
-    if (callback) {
-      callback();
-    }
+    callback();
   };
   const onParameterChange = (of: keyof Swap) => (name: string, value: string) =>
     dispatch({
@@ -183,11 +181,9 @@ function SwapForm({
             selection={alphaLedger}
             options={ledgerOptions}
             disabledOptions={[betaLedger.name]}
-            onSelectionChange={
-              onAlphaLedgerChange
-                ? onSelectionChange("alpha_ledger", () => onAlphaLedgerChange())
-                : onSelectionChange("alpha_ledger")
-            }
+            onSelectionChange={onSelectionChange("alpha_ledger", () =>
+              onAlphaLedgerChange()
+            )}
             onParameterChange={onParameterChange("alpha_ledger")}
             parameters={alphaLedgerSpec.parameters}
             dataCy="ledger-select"
@@ -199,7 +195,9 @@ function SwapForm({
               selection={alphaAsset}
               options={alphaAssetOptions}
               disabledOptions={[]}
-              onSelectionChange={onSelectionChange("alpha_asset")}
+              onSelectionChange={onSelectionChange("alpha_asset", () =>
+                onAlphaLedgerChange()
+              )}
               onParameterChange={onParameterChange("alpha_asset")}
               parameters={alphaAssetSpec.parameters}
               dataCy="asset-select"
@@ -215,11 +213,9 @@ function SwapForm({
             selection={betaLedger}
             options={ledgerOptions}
             disabledOptions={[alphaLedger.name]}
-            onSelectionChange={
-              onBetaLedgerChange
-                ? onSelectionChange("beta_ledger", () => onBetaLedgerChange())
-                : onSelectionChange("beta_ledger")
-            }
+            onSelectionChange={onSelectionChange("beta_ledger", () =>
+              onBetaLedgerChange()
+            )}
             onParameterChange={onParameterChange("beta_ledger")}
             parameters={betaLedgerSpec.parameters}
             dataCy="ledger-select"
@@ -231,7 +227,9 @@ function SwapForm({
               selection={betaAsset}
               options={betaAssetOptions}
               disabledOptions={[]}
-              onSelectionChange={onSelectionChange("beta_asset")}
+              onSelectionChange={onSelectionChange("beta_asset", () =>
+                onBetaLedgerChange()
+              )}
               onParameterChange={onParameterChange("beta_asset")}
               parameters={betaAssetSpec.parameters}
               dataCy="asset-select"

--- a/src/forms/SwapForm.tsx
+++ b/src/forms/SwapForm.tsx
@@ -115,10 +115,19 @@ interface Props {
   swap: Swap;
   ledgers: LedgerSpec[];
   dispatch: Dispatch<Action>;
+  onAlphaLedgerChange?: () => void;
+  onBetaLedgerChange?: () => void;
   disabled?: boolean;
 }
 
-function SwapForm({ swap, ledgers, dispatch, disabled = false }: Props) {
+function SwapForm({
+  swap,
+  ledgers,
+  dispatch,
+  onAlphaLedgerChange,
+  onBetaLedgerChange,
+  disabled = false
+}: Props) {
   const alphaLedger = swap.alpha_ledger;
   const betaLedger = swap.beta_ledger;
   const alphaAsset = swap.alpha_asset;
@@ -146,12 +155,18 @@ function SwapForm({ swap, ledgers, dispatch, disabled = false }: Props) {
     label: asset.label
   }));
 
-  const onSelectionChange = (of: keyof Swap) => (selection: string) =>
+  const onSelectionChange = (of: keyof Swap, callback?: () => void) => (
+    selection: string
+  ) => {
     dispatch({
       type: "change-selection",
       of,
       payload: { newSelection: selection }
     });
+    if (callback) {
+      callback();
+    }
+  };
   const onParameterChange = (of: keyof Swap) => (name: string, value: string) =>
     dispatch({
       of,
@@ -168,7 +183,11 @@ function SwapForm({ swap, ledgers, dispatch, disabled = false }: Props) {
             selection={alphaLedger}
             options={ledgerOptions}
             disabledOptions={[betaLedger.name]}
-            onSelectionChange={onSelectionChange("alpha_ledger")}
+            onSelectionChange={
+              onAlphaLedgerChange
+                ? onSelectionChange("alpha_ledger", () => onAlphaLedgerChange())
+                : onSelectionChange("alpha_ledger")
+            }
             onParameterChange={onParameterChange("alpha_ledger")}
             parameters={alphaLedgerSpec.parameters}
             dataCy="ledger-select"
@@ -196,7 +215,11 @@ function SwapForm({ swap, ledgers, dispatch, disabled = false }: Props) {
             selection={betaLedger}
             options={ledgerOptions}
             disabledOptions={[alphaLedger.name]}
-            onSelectionChange={onSelectionChange("beta_ledger")}
+            onSelectionChange={
+              onBetaLedgerChange
+                ? onSelectionChange("beta_ledger", () => onBetaLedgerChange())
+                : onSelectionChange("beta_ledger")
+            }
             onParameterChange={onParameterChange("beta_ledger")}
             parameters={betaLedgerSpec.parameters}
             dataCy="ledger-select"

--- a/src/pages/SendSwapRequest/Select.tsx
+++ b/src/pages/SendSwapRequest/Select.tsx
@@ -20,7 +20,7 @@ interface SelectProps {
   disabledOptions?: string[];
   label: string;
   parameters: Parameter[];
-  onSelectionChange: (selection: string) => void;
+  onSelectionChange: (selection: string, callback?: () => void) => void;
   onParameterChange: (name: string, value: string) => void;
   dataCy?: string;
   disabled?: boolean;

--- a/src/pages/SendSwapRequest/SendSwapRequest.tsx
+++ b/src/pages/SendSwapRequest/SendSwapRequest.tsx
@@ -11,6 +11,8 @@ import SendButton from "../../components/SendButton";
 import TextField from "../../components/TextField";
 import Rfc003ParamsForm, {
   defaultRfc003Params,
+  resetAlphaIdentity,
+  resetBetaIdentity,
   Rfc003Params
 } from "../../forms/Rfc003ParamsForm";
 import SwapForm, {
@@ -50,7 +52,13 @@ const SendSwap = ({ location, history }: RouteComponentProps) => {
       <Page title={"Send a swap request"}>
         <form onSubmit={handleFormSubmit}>
           <Grid container={true} spacing={16}>
-            <SwapForm swap={swap} ledgers={ledgers} dispatch={dispatch} />
+            <SwapForm
+              swap={swap}
+              ledgers={ledgers}
+              dispatch={dispatch}
+              onAlphaLedgerChange={() => setParams(resetAlphaIdentity(params))}
+              onBetaLedgerChange={() => setParams(resetBetaIdentity(params))}
+            />
             <Grid item={true} xs={12}>
               <Fieldset legend="Protocol Parameters">
                 <Grid item={true} xs={12} md={6}>


### PR DESCRIPTION
The bug described in #48 was occurring again because `resetParams` was exported but not used after some changes were made.

`resetParams` has been split up into `resetAlphaIdentity` and `resetBetaIdentity` which are passed as callbacks to `onSelectionChange`. When a ledger selection in the send swap form changes, the corresponding identity is assigned its default value `undefined`.

Resolves #48.