### PR TITLE
A few fixes to do with links

### DIFF
--- a/src/ledgerSpec.ts
+++ b/src/ledgerSpec.ts
@@ -45,7 +45,8 @@ const ledgers: LedgerSpec[] = [
             name: "quantity",
             label: "Quantity",
             type: ParameterKind.Quantity,
-            unit: "BTC"
+            unit: "BTC",
+            smallestUnit: "sat"
           }
         ]
       }
@@ -70,7 +71,9 @@ const ledgers: LedgerSpec[] = [
           {
             name: "quantity",
             label: "Quantity",
-            type: ParameterKind.Quantity
+            type: ParameterKind.Quantity,
+            unit: "ETH",
+            smallestUnit: "wei"
           }
         ]
       },
@@ -81,8 +84,7 @@ const ledgers: LedgerSpec[] = [
           {
             name: "quantity",
             label: "Quantity",
-            type: ParameterKind.Quantity,
-            unit: "ETH"
+            type: ParameterKind.Quantity
           },
           {
             name: "token_contract",

--- a/src/pages/LinkLandingPage/parseSwapParams.ts
+++ b/src/pages/LinkLandingPage/parseSwapParams.ts
@@ -8,7 +8,6 @@ export interface SwapParams {
   betaAsset: SwapValue;
   protocol: string;
   peer: string;
-  id: string;
 }
 
 export default function parseSwapParams(queryParams: QueryParams): SwapParams {
@@ -20,7 +19,6 @@ export default function parseSwapParams(queryParams: QueryParams): SwapParams {
 
   const protocol = parseProtocol(queryParams.protocol);
   const peer = parsePeer(queryParams.peer);
-  const id = "42";
 
   return {
     alphaLedger,
@@ -28,8 +26,7 @@ export default function parseSwapParams(queryParams: QueryParams): SwapParams {
     betaLedger,
     betaAsset,
     protocol,
-    peer,
-    id
+    peer
   };
 }
 

--- a/src/pages/LinkLandingPage/parseSwapParams.ts
+++ b/src/pages/LinkLandingPage/parseSwapParams.ts
@@ -1,3 +1,5 @@
+import { toSatoshi } from "satoshi-bitcoin-ts";
+import { toWei } from "web3-utils";
 import { SwapValue } from "../../forms/SwapForm";
 import { QueryParams } from "./parseQuery";
 
@@ -71,6 +73,20 @@ function tokenIdToAssetParameter(asset: string, tokenId: string) {
   }
 }
 
+function toDisplayUnit(symbol: string, quantity: string) {
+  switch (symbol) {
+    case "BTC": {
+      return toSatoshi(quantity).toString();
+    }
+    case "ETH": {
+      return toWei(quantity);
+    }
+    case "ERC20":
+    default:
+      return quantity;
+  }
+}
+
 function parseAsset(input: string | undefined, asset: string): SwapValue {
   if (!input) {
     throw new Error(asset + " undefined");
@@ -81,12 +97,13 @@ function parseAsset(input: string | undefined, asset: string): SwapValue {
   if (!match.length || !match[1] || !match[2]) {
     throw new Error(asset + " asset could not be parsed. Was: " + input);
   }
-  const quantity = match[1];
+  let quantity = match[1];
   const symbol = match[2];
   const tokenId = match[4];
 
   const name = symbolToAssetName(symbol);
   const tokenIdParameters = tokenIdToAssetParameter(name, tokenId);
+  quantity = toDisplayUnit(symbol, quantity);
 
   return { name, quantity, ...tokenIdParameters };
 }

--- a/src/pages/MakeLink/MakeLink.tsx
+++ b/src/pages/MakeLink/MakeLink.tsx
@@ -113,27 +113,15 @@ const MakeLink = () => {
           <SubTitle text={"The generated link"} />
           <Paper elevation={2}>
             <Grid container={true} spacing={16} alignItems={"center"}>
-              <Grid
-                item={true}
-                container={true}
-                xs={2}
-                md={1}
-                justify={"center"}
-              >
+              <Grid item={true} container={true} xs={2} justify={"center"}>
                 {icon}
               </Grid>
-              <Grid item={true} xs={8} md={10}>
-                <Typography variant={"body2"} align={"center"}>
+              <Grid item={true} xs={8}>
+                <Typography noWrap={true} variant={"body2"} align={"center"}>
                   {uri.toString()}
                 </Typography>
               </Grid>
-              <Grid
-                item={true}
-                container={true}
-                xs={2}
-                md={1}
-                justify={"center"}
-              >
+              <Grid item={true} container={true} xs={2} justify={"center"}>
                 {!linkIsValid ? (
                   <Tooltip
                     title={"Please complete the form before copying the link."}

--- a/src/pages/MakeLink/MakeLink.tsx
+++ b/src/pages/MakeLink/MakeLink.tsx
@@ -4,7 +4,9 @@ import ErrorOutlined from "@material-ui/icons/ErrorOutlined";
 import FileCopy from "@material-ui/icons/FileCopy";
 import copy from "copy-to-clipboard";
 import React, { useReducer, useState } from "react";
+import { toBitcoin } from "satoshi-bitcoin-ts";
 import URI from "urijs";
+import { fromWei } from "web3-utils";
 import Page from "../../components/Page";
 import { SubTitle } from "../../components/text";
 import TextField from "../../components/TextField";
@@ -172,10 +174,10 @@ function assetToQueryValue(value: SwapValue) {
   if (value.quantity) {
     switch (value.name) {
       case "bitcoin": {
-        return `${value.quantity}BTC`;
+        return `${toBitcoin(value.quantity, true)}BTC`;
       }
       case "ether": {
-        return `${value.quantity}ETH`;
+        return `${fromWei(value.quantity)}ETH`;
       }
     }
   }

--- a/src/pages/SendSwapRequest/Select.tsx
+++ b/src/pages/SendSwapRequest/Select.tsx
@@ -1,4 +1,4 @@
-import { Grid } from "@material-ui/core";
+import { Grid, InputAdornment } from "@material-ui/core";
 import pascalCase from "pascal-case";
 import React from "react";
 import TextField from "../../components/TextField";
@@ -110,6 +110,15 @@ function Select({
                     }}
                     data-cy="quantity-input"
                     disabled={disabled}
+                    InputProps={
+                      param.smallestUnit && {
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            {param.smallestUnit}
+                          </InputAdornment>
+                        )
+                      }
+                    }
                   />
                 </Grid>
               );


### PR DESCRIPTION
Resolves #56.
Resolves #55.

![Jun03::203255](https://user-images.githubusercontent.com/9418575/58825777-770e5380-863f-11e9-8426-9b56ac2e3f5a.png)

As you can see I didn't go for anything fancy to fix #55. I don't know how to format a long string without spaces like a url, so I went for ellipsis.

The value entered here (and in the swap request form) is in the smallest unit (satoshi, wei) but is encoded in the main unit. It is then correctly decoded on the swap link landing page.

![Jun03::204722](https://user-images.githubusercontent.com/9418575/58826902-0ddc0f80-8642-11e9-912e-2fe396176389.png)

Unit adornments were added for satoshi and wei.