### PR TITLE
Display main asset unit in UI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
+addons:
+  apt:
+    packages:
+      - libgconf-2-4
 cache:
   directories:
     - "~/.cache/Cypress"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-select": "^2.0.17",
     "@types/uuidjs": "^3.6.0",
     "axios": "^0.18.0",
+    "axios-mock-adapter": "^1.16.0",
     "classnames": "^2.2.6",
     "content-type": "^1.0.4",
     "copy-to-clipboard": "^3.2.0",

--- a/src/api/postRfc003Swap.spec.ts
+++ b/src/api/postRfc003Swap.spec.ts
@@ -1,0 +1,65 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import apiEndpoint from "./apiEndpoint";
+import postRfc003Swap from "./postRfc003Swap";
+
+describe("postRfc003Swap", () => {
+  it("should build the request using smallest units", done => {
+    const mock = new MockAdapter(axios);
+
+    mock
+      .onPost(
+        apiEndpoint()
+          .path("swaps/rfc003")
+          .toString()
+      )
+      .replyOnce(200);
+
+    const alphaQuantity = "3";
+    const alphaQuantityInSatoshi = "300000000";
+
+    const betaQuantity = "4";
+    const betaQuantityInWei = "4000000000000000000";
+
+    const swapDetails = {
+      alpha_ledger: {
+        name: "bitcoin",
+        network: "regtest"
+      },
+      alpha_asset: {
+        name: "bitcoin",
+        quantity: alphaQuantity
+      },
+      beta_ledger: {
+        name: "ethereum",
+        network: "regtest"
+      },
+      beta_asset: {
+        name: "ether",
+        quantity: betaQuantity
+      }
+    };
+
+    const rfc003Params = {
+      alpha_expiry: 20,
+      beta_expiry: 10,
+      beta_ledger_redeem_identity: "0x493a5a0eafdeae28f430f74ac5031b3ee37b6a6d"
+    };
+
+    const peerId = "QmPRNaiDUcJmnuJWUyoADoqvFotwaMRFKV2RyZ7ZVr1fqd";
+
+    postRfc003Swap(swapDetails, rfc003Params, peerId)
+      .then(() => {
+        expect(JSON.parse(mock.history.post[0].data)).toHaveProperty(
+          "alpha_asset.quantity",
+          alphaQuantityInSatoshi
+        );
+        expect(JSON.parse(mock.history.post[0].data)).toHaveProperty(
+          "beta_asset.quantity",
+          betaQuantityInWei
+        );
+      })
+      .then(done)
+      .catch(done.fail);
+  });
+});

--- a/src/api/postRfc003Swap.ts
+++ b/src/api/postRfc003Swap.ts
@@ -24,7 +24,7 @@ export default function postRfc003Swap(
   swap: Swap,
   params: Rfc003Params,
   peerId: string,
-  addressHint: string
+  addressHint?: string
 ) {
   const uri = apiEndpoint()
     .path("swaps/rfc003")

--- a/src/api/postRfc003Swap.ts
+++ b/src/api/postRfc003Swap.ts
@@ -1,9 +1,24 @@
 import axios from "axios";
 import update from "immutability-helper";
 import { Rfc003Params } from "../forms/Rfc003ParamsForm";
-import { Swap } from "../forms/SwapForm";
+import { Swap, SwapValue } from "../forms/SwapForm";
 import { relativeMinutesToTimestamp } from "../time";
 import apiEndpoint from "./apiEndpoint";
+import { toSmallestUnit } from "./unit";
+
+function adjustAssetUnit(value: SwapValue) {
+  const asset = {
+    name: value.name,
+    quantity: value.quantity as string,
+    token_contract: value.token_contract
+  };
+
+  const adjustedQuantity = toSmallestUnit(asset);
+
+  return update(asset, {
+    quantity: { $set: adjustedQuantity }
+  });
+}
 
 export default function postRfc003Swap(
   swap: Swap,
@@ -14,6 +29,15 @@ export default function postRfc003Swap(
   const uri = apiEndpoint()
     .path("swaps/rfc003")
     .toString();
+
+  const adjustedSwap = update(swap, {
+    alpha_asset: {
+      $apply: adjustAssetUnit
+    },
+    beta_asset: {
+      $apply: adjustAssetUnit
+    }
+  });
 
   const adjustedParams = update(params, {
     alpha_expiry: { $apply: relativeMinutesToTimestamp },
@@ -28,7 +52,7 @@ export default function postRfc003Swap(
   return axios.post(
     uri,
     {
-      ...swap,
+      ...adjustedSwap,
       ...adjustedParams,
       peer: peer ? peer : peerId
     },

--- a/src/api/swapTypes.ts
+++ b/src/api/swapTypes.ts
@@ -1,23 +1,7 @@
-import { toBitcoin } from "satoshi-bitcoin-ts";
-import { fromWei } from "web3-utils";
-
 export interface Asset {
   name: string;
   quantity: string;
   token_contract?: string;
-}
-
-export function toMainUnit(asset: Asset) {
-  switch (asset.name) {
-    case "ether":
-      return fromWei(asset.quantity, "ether") + " ETH";
-    case "bitcoin":
-      return toBitcoin(asset.quantity, true) + " BTC";
-    case "erc20":
-      return asset.quantity + " ERC20";
-    default:
-      return asset.quantity + " " + asset.name;
-  }
 }
 
 export interface Ledger {

--- a/src/api/unit.ts
+++ b/src/api/unit.ts
@@ -1,0 +1,28 @@
+import { toBitcoin } from "satoshi-bitcoin-ts";
+import { fromWei } from "web3-utils";
+import { Asset } from "./swapTypes";
+
+export function toMainUnit(asset: Asset) {
+  switch (asset.name) {
+    case "ether":
+      return fromWei(asset.quantity, "ether");
+    case "bitcoin":
+      return toBitcoin(asset.quantity, true).toString();
+    case "erc20":
+    default:
+      return asset.quantity;
+  }
+}
+
+export function mainUnitSymbol(asset: Asset) {
+  switch (asset.name) {
+    case "ether":
+      return "ETH";
+    case "bitcoin":
+      return "BTC";
+    case "erc20":
+      return "ERC20";
+    default:
+      return asset.name;
+  }
+}

--- a/src/api/unit.ts
+++ b/src/api/unit.ts
@@ -1,5 +1,5 @@
-import { toBitcoin } from "satoshi-bitcoin-ts";
-import { fromWei } from "web3-utils";
+import { toBitcoin, toSatoshi } from "satoshi-bitcoin-ts";
+import { fromWei, toWei } from "web3-utils";
 import { Asset } from "./swapTypes";
 
 export function toMainUnit(asset: Asset) {
@@ -8,6 +8,18 @@ export function toMainUnit(asset: Asset) {
       return fromWei(asset.quantity, "ether");
     case "bitcoin":
       return toBitcoin(asset.quantity, true).toString();
+    case "erc20":
+    default:
+      return asset.quantity;
+  }
+}
+
+export function toSmallestUnit(asset: Asset) {
+  switch (asset.name) {
+    case "ether":
+      return toWei(asset.quantity);
+    case "bitcoin":
+      return toSatoshi(asset.quantity).toString();
     case "erc20":
     default:
       return asset.quantity;

--- a/src/pages/LinkLandingPage/parseSwapParams.ts
+++ b/src/pages/LinkLandingPage/parseSwapParams.ts
@@ -1,5 +1,3 @@
-import { toSatoshi } from "satoshi-bitcoin-ts";
-import { toWei } from "web3-utils";
 import { SwapValue } from "../../forms/SwapForm";
 import { QueryDialInfo, QueryParams } from "./parseQuery";
 
@@ -75,20 +73,6 @@ function tokenIdToAssetParameter(asset: string, tokenId: string) {
   }
 }
 
-function toDisplayUnit(symbol: string, quantity: string) {
-  switch (symbol) {
-    case "BTC": {
-      return toSatoshi(quantity).toString();
-    }
-    case "ETH": {
-      return toWei(quantity);
-    }
-    case "ERC20":
-    default:
-      return quantity;
-  }
-}
-
 function parseAsset(input: string | undefined, asset: string): SwapValue {
   if (!input) {
     throw new Error(asset + " undefined");
@@ -99,13 +83,12 @@ function parseAsset(input: string | undefined, asset: string): SwapValue {
   if (!match.length || !match[1] || !match[2]) {
     throw new Error(asset + " asset could not be parsed. Was: " + input);
   }
-  let quantity = match[1];
+  const quantity = match[1];
   const symbol = match[2];
   const tokenId = match[4];
 
   const name = symbolToAssetName(symbol);
   const tokenIdParameters = tokenIdToAssetParameter(name, tokenId);
-  quantity = toDisplayUnit(symbol, quantity);
 
   return { name, quantity, ...tokenIdParameters };
 }

--- a/src/pages/MakeLink/MakeLink.tsx
+++ b/src/pages/MakeLink/MakeLink.tsx
@@ -5,9 +5,7 @@ import FileCopy from "@material-ui/icons/FileCopy";
 import copy from "copy-to-clipboard";
 import React, { useReducer, useState } from "react";
 import { useAsync } from "react-async";
-import { toBitcoin } from "satoshi-bitcoin-ts";
 import URI from "urijs";
-import { fromWei } from "web3-utils";
 import getComitInfo from "../../api/getComitInfo";
 import Fieldset from "../../components/Fieldset";
 import Page from "../../components/Page";
@@ -212,10 +210,10 @@ function assetToQueryValue(value: SwapValue) {
   if (value.quantity) {
     switch (value.name) {
       case "bitcoin": {
-        return `${toBitcoin(value.quantity, true)}BTC`;
+        return `${value.quantity}BTC`;
       }
       case "ether": {
-        return `${fromWei(value.quantity)}ETH`;
+        return `${value.quantity}ETH`;
       }
       case "erc20": {
         return `${value.quantity}ERC20:${value.token_contract}`;

--- a/src/pages/SendSwapRequest/Select.tsx
+++ b/src/pages/SendSwapRequest/Select.tsx
@@ -111,10 +111,10 @@ function Select({
                     data-cy="quantity-input"
                     disabled={disabled}
                     InputProps={
-                      param.smallestUnit && {
+                      param.unit && {
                         endAdornment: (
                           <InputAdornment position="end">
-                            {param.smallestUnit}
+                            {param.unit}
                           </InputAdornment>
                         )
                       }

--- a/src/pages/SwapList/LedgerActionDialogBody.tsx
+++ b/src/pages/SwapList/LedgerActionDialogBody.tsx
@@ -7,6 +7,7 @@ import {
 } from "@material-ui/core";
 import React from "react";
 import { LedgerAction } from "../../api/getAction";
+import { toMainUnit } from "../../api/unit";
 import Web3SendTransactionButton from "../../components/Web3SendTransactionButton";
 import CopyToClipboardButton from "./CopyToClipboard";
 
@@ -56,21 +57,23 @@ function LedgerActionDialogBody({
       );
     }
     case "bitcoin-send-amount-to-address": {
+      const amount = toMainUnit({
+        name: "bitcoin",
+        quantity: action.payload.amount
+      });
+
       return (
         <React.Fragment>
           <DialogTitle>Send Bitcoin</DialogTitle>
           <DialogContent>
             <Typography paragraph={true}>
-              Please send <b>{action.payload.amount}</b> satoshi to the
-              following <b>{action.payload.network}</b> address:
+              Please send <b>{amount}</b> BTC to the following{" "}
+              <b>{action.payload.network}</b> address:
             </Typography>
             {action.payload.to}
           </DialogContent>
           <DialogActions>
-            <CopyToClipboardButton
-              content={action.payload.amount}
-              name="amount"
-            />
+            <CopyToClipboardButton content={amount} name="amount" />
             <CopyToClipboardButton content={action.payload.to} name="address" />
             <Button onClick={onClose} color="secondary">
               Close
@@ -79,15 +82,22 @@ function LedgerActionDialogBody({
         </React.Fragment>
       );
     }
+    /* This action is too generic and it doesn't differentiate between ether
+         and ERC20. This is enough for performing the action, but not for
+         informing the user about what the action does */
     case "ethereum-deploy-contract": {
+      const amount = toMainUnit({
+        name: "ether",
+        quantity: action.payload.amount
+      });
+
       return (
         <React.Fragment>
           <DialogTitle>Deploy Ethereum contract</DialogTitle>
           <DialogContent>
             <Typography paragraph={true}>
               Deploy the following contract to the Ethereum{" "}
-              <b>{action.payload.network}</b> network with{" "}
-              <b>{action.payload.amount}</b> wei:
+              <b>{action.payload.network}</b> network with <b>{amount}</b> ETH:
             </Typography>
             <Typography
               variant={"body1"}

--- a/src/pages/SwapList/SwapRow/SwapRow.tsx
+++ b/src/pages/SwapList/SwapRow/SwapRow.tsx
@@ -3,7 +3,8 @@ import { makeStyles } from "@material-ui/styles";
 import React, { useReducer } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { EmbeddedRepresentationSubEntity } from "../../../../gen/siren";
-import { Asset, Properties, toMainUnit } from "../../../api/swapTypes";
+import { Asset, Properties } from "../../../api/swapTypes";
+import { mainUnitSymbol, toMainUnit } from "../../../api/unit";
 import ActionButton from "../../../components/ActionButton";
 import Dialog from "../../../components/Dialog";
 import ExternalLink from "../../../components/ExternalLink";
@@ -29,7 +30,7 @@ interface AssetCellProps {
 }
 
 function AssetCell({ asset }: AssetCellProps) {
-  return <span>{toMainUnit(asset)}</span>;
+  return <span>{toMainUnit(asset) + " " + mainUnitSymbol(asset)}</span>;
 }
 
 const useStyles = makeStyles(() => ({

--- a/src/pages/SwapList/__snapshots__/LedgerActionDialogBody.spec.tsx.snap
+++ b/src/pages/SwapList/__snapshots__/LedgerActionDialogBody.spec.tsx.snap
@@ -132,9 +132,10 @@ Array [
     >
       Please send 
       <b>
-        100000000
+        1
       </b>
-       satoshi to the following 
+       BTC to the following
+       
       <b>
         regtest
       </b>
@@ -523,12 +524,11 @@ Array [
       <b>
         regtest
       </b>
-       network with
-       
+       network with 
       <b>
-        111111111111111111111
+        111.111111111111111111
       </b>
-       wei:
+       ETH:
     </p>
     <p
       className="MuiTypography-root MuiTypography-body1"

--- a/src/pages/SwapPage/AssetCard.tsx
+++ b/src/pages/SwapPage/AssetCard.tsx
@@ -13,7 +13,8 @@ import { makeStyles } from "@material-ui/styles";
 import classnames from "classnames";
 import moment from "moment";
 import React, { useState } from "react";
-import { Asset, Ledger, toMainUnit } from "../../api/swapTypes";
+import { Asset, Ledger } from "../../api/swapTypes";
+import { mainUnitSymbol, toMainUnit } from "../../api/unit";
 import ExplorerLink, { ResourceType } from "./ExplorerLink";
 
 const useStyles = makeStyles<Theme>(theme => ({
@@ -58,6 +59,8 @@ function AssetCard({
           tradeAction +
           " " +
           toMainUnit(asset) +
+          " " +
+          mainUnitSymbol(asset) +
           " on " +
           ledger.name +
           " " +

--- a/stories/LedgerActionDialog.tsx
+++ b/stories/LedgerActionDialog.tsx
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/react";
 import { Button, Dialog } from "@material-ui/core";
-import LedgerActionDialogBody from "../src/pages/ListSwaps/LedgerActionDialogBody";
+import LedgerActionDialogBody from "../src/pages/SwapList/LedgerActionDialogBody";
 import { Store, withState } from "@dump247/storybook-state";
 import React from "react";
 

--- a/stories/SirenActionDialog.tsx
+++ b/stories/SirenActionDialog.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from "@material-ui/styles";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import { Web3Provider } from "../src/components/Web3Context";
-import SirenActionParametersDialogBody from "../src/pages/ListSwaps/SirenActionParametersDialogBody";
+import SirenActionParametersDialogBody from "../src/pages/SwapList/SirenActionParametersDialogBody";
 import appTheme from "../src/theme";
 
 interface DialogStoryState {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3336,6 +3336,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios-mock-adapter@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.16.0.tgz#cdd55bb60d8cb3fcd77fdb9cbb269e47b8b95180"
+  integrity sha512-m2D8ngMTQ5p4zZNBsPKoENgwz5rDfd0pZmXI/spdE2eeeKIcR3jquk+NRiBVFtb9UJlciBYplNzSUmgQ6X385Q==
+  dependencies:
+    deep-equal "^1.0.1"
+
 axios@*, axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"


### PR DESCRIPTION
Display the main unit of an asset (bitcoin, ether) instead of the smallest unit (satoshi, wei) everywhere in the UI (create link page, link landing page, send swap page and action dialogs).

Also fix travis builds: https://github.com/cypress-io/cypress/issues/4069#issuecomment-488816887