### PR TITLE
Continuously reload comit resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/moment": "^2.13.0",
     "@types/react-select": "^2.0.17",
     "@types/uuidjs": "^3.6.0",
+    "@use-it/interval": "^0.1.3",
     "axios": "^0.18.0",
     "axios-mock-adapter": "^1.16.0",
     "classnames": "^2.2.6",

--- a/src/components/ErrorSnackbar.tsx
+++ b/src/components/ErrorSnackbar.tsx
@@ -1,82 +1,25 @@
-import {
-  createStyles,
-  IconButton,
-  Snackbar,
-  SnackbarContent,
-  Theme,
-  Typography,
-  WithStyles,
-  withStyles
-} from "@material-ui/core";
-import CloseIcon from "@material-ui/icons/Close";
 import ErrorIcon from "@material-ui/icons/Error";
 import React from "react";
+import Snackbar from "./Snackbar";
 
-const styles = (theme: Theme) =>
-  createStyles({
-    content: {
-      backgroundColor: theme.palette.error.dark
-    },
-    message: {
-      display: "flex",
-      alignItems: "center"
-    },
-    icon: {
-      marginRight: theme.spacing(1)
-    }
-  });
-
-interface ErrorSnackbarProps extends WithStyles<typeof styles> {
+interface ErrorSnackbarProps {
   open: boolean;
   onClose?: () => void;
   message: string;
 }
 
-function ErrorSnackbar({
-  open,
-  onClose,
-  message,
-  classes
-}: ErrorSnackbarProps) {
+function ErrorSnackbar({ open, onClose, message }: ErrorSnackbarProps) {
   return (
     <Snackbar
-      data-cy="error-snackbar"
-      anchorOrigin={{
-        vertical: "bottom",
-        horizontal: "left"
-      }}
       open={open}
       onClose={onClose}
-      ClickAwayListenerProps={{
-        onClickAway: () => undefined
-      }}
-    >
-      <SnackbarContent
-        classes={{
-          root: classes.content,
-          message: classes.message
-        }}
-        message={
-          <React.Fragment>
-            <ErrorIcon className={classes.icon} />
-            <Typography color={"inherit"}>{message}</Typography>
-          </React.Fragment>
-        }
-        action={
-          onClose && [
-            <IconButton
-              key="close"
-              aria-label="Close"
-              color="inherit"
-              onClick={onClose}
-            >
-              <CloseIcon />
-            </IconButton>
-          ]
-        }
-      />
-    </Snackbar>
+      message={message}
+      icon={ErrorIcon}
+      backgroundPaletteVariant="error"
+      backgroundColor="dark"
+      data-cy="error-snackbar"
+    />
   );
 }
 
-export default withStyles(styles)(ErrorSnackbar);
+export default ErrorSnackbar;

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -1,0 +1,98 @@
+import {
+  IconButton,
+  Snackbar as MaterialSnackbar,
+  SnackbarContent,
+  Theme,
+  Typography
+} from "@material-ui/core";
+import { SnackbarProps as MaterialSnackbarProps } from "@material-ui/core/Snackbar";
+import CloseIcon from "@material-ui/icons/Close";
+import { makeStyles } from "@material-ui/styles";
+import React from "react";
+
+const useStyles = makeStyles<Theme, StyleProps>((theme: Theme) => ({
+  content: ({ paletteVariant, color }) => ({
+    backgroundColor: theme.palette[paletteVariant][color]
+  }),
+  message: {
+    display: "flex",
+    alignItems: "center"
+  },
+  icon: {
+    marginRight: theme.spacing(1)
+  }
+}));
+
+type PaletteColorVariant = "primary" | "secondary" | "error";
+type PaletteColor = "light" | "dark" | "main";
+
+interface StyleProps {
+  paletteVariant: PaletteColorVariant;
+  color: PaletteColor;
+}
+
+interface SnackbarProps {
+  open: boolean;
+  onClose?: () => void;
+  message: string;
+  icon: React.ComponentType<any>;
+  backgroundPaletteVariant: PaletteColorVariant;
+  backgroundColor: PaletteColor;
+}
+
+function Snackbar({
+  open,
+  onClose,
+  message,
+  icon,
+  backgroundPaletteVariant,
+  backgroundColor,
+  ...remainingProps
+}: SnackbarProps & MaterialSnackbarProps) {
+  const classes = useStyles({
+    paletteVariant: backgroundPaletteVariant,
+    color: backgroundColor
+  });
+
+  return (
+    <MaterialSnackbar
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left"
+      }}
+      open={open}
+      onClose={onClose}
+      ClickAwayListenerProps={{
+        onClickAway: () => undefined
+      }}
+      {...remainingProps}
+    >
+      <SnackbarContent
+        classes={{
+          root: classes.content,
+          message: classes.message
+        }}
+        message={
+          <React.Fragment>
+            {React.createElement(icon, { className: classes.icon }, [])}
+            <Typography color={"inherit"}>{message}</Typography>
+          </React.Fragment>
+        }
+        action={
+          onClose && [
+            <IconButton
+              key="close"
+              aria-label="Close"
+              color="inherit"
+              onClick={onClose}
+            >
+              <CloseIcon />
+            </IconButton>
+          ]
+        }
+      />
+    </MaterialSnackbar>
+  );
+}
+
+export default Snackbar;

--- a/src/components/SuccessSnackbar.tsx
+++ b/src/components/SuccessSnackbar.tsx
@@ -1,80 +1,24 @@
-// TODO: Create generic Snackbar component out of this and ErrorSnackbar
-import {
-  createStyles,
-  IconButton,
-  Snackbar,
-  SnackbarContent,
-  Theme,
-  Typography,
-  WithStyles,
-  withStyles
-} from "@material-ui/core";
-import CloseIcon from "@material-ui/icons/Close";
 import DoneIcon from "@material-ui/icons/Done";
 import React from "react";
+import Snackbar from "./Snackbar";
 
-const styles = (theme: Theme) =>
-  createStyles({
-    content: {
-      backgroundColor: theme.palette.primary.dark
-    },
-    message: {
-      display: "flex",
-      alignItems: "center"
-    },
-    icon: {
-      marginRight: theme.spacing(1)
-    }
-  });
-
-interface SuccessSnackbarProps extends WithStyles<typeof styles> {
+interface SuccessSnackbarProps {
   open: boolean;
-  onClose: () => void;
+  onClose?: () => void;
   message: string;
 }
 
-function SuccessSnackbar({
-  open,
-  onClose,
-  message,
-  classes
-}: SuccessSnackbarProps) {
+function SuccessSnackbar({ open, onClose, message }: SuccessSnackbarProps) {
   return (
     <Snackbar
-      anchorOrigin={{
-        vertical: "bottom",
-        horizontal: "left"
-      }}
       open={open}
       onClose={onClose}
-      ClickAwayListenerProps={{
-        onClickAway: () => undefined
-      }}
-    >
-      <SnackbarContent
-        classes={{
-          root: classes.content,
-          message: classes.message
-        }}
-        message={
-          <React.Fragment>
-            <DoneIcon className={classes.icon} />
-            <Typography color={"inherit"}>{message}</Typography>
-          </React.Fragment>
-        }
-        action={[
-          <IconButton
-            key="close"
-            aria-label="Close"
-            color="inherit"
-            onClick={onClose}
-          >
-            <CloseIcon />
-          </IconButton>
-        ]}
-      />
-    </Snackbar>
+      message={message}
+      icon={DoneIcon}
+      backgroundPaletteVariant="primary"
+      backgroundColor="dark"
+    />
   );
 }
 
-export default withStyles(styles)(SuccessSnackbar);
+export default SuccessSnackbar;

--- a/src/pages/LinkLandingPage/LinkLandingPage.tsx
+++ b/src/pages/LinkLandingPage/LinkLandingPage.tsx
@@ -84,6 +84,10 @@ const LinkLandingPage = ({ location, history }: RouteComponentProps) => {
     );
   };
 
+  const onClose = () => {
+    setDisplayError(false);
+  };
+
   return (
     <React.Fragment>
       <Page title={"Send a swap request"}>
@@ -141,7 +145,7 @@ const LinkLandingPage = ({ location, history }: RouteComponentProps) => {
 
       <ErrorSnackbar
         message={"Failed to create swap."}
-        onClose={() => setDisplayError(false)}
+        onClose={onClose}
         open={displayError}
       />
     </React.Fragment>

--- a/src/pages/ShowResource.tsx
+++ b/src/pages/ShowResource.tsx
@@ -107,13 +107,13 @@ function ShowResource({ location }: RouteComponentProps) {
     <React.Fragment>
       {resource()}
       <Snackbar
-        open={!axiosError && !allowReload && showLoading}
+        open={!axiosError && allowReload && showLoading}
         onClose={() => setShowLoading(false)}
         message="Loading"
         icon={CircularProgress}
         backgroundPaletteVariant="primary"
         backgroundColor="dark"
-        autoHideDuration={3000}
+        autoHideDuration={1000}
       />
     </React.Fragment>
   );

--- a/src/pages/ShowResource.tsx
+++ b/src/pages/ShowResource.tsx
@@ -1,6 +1,6 @@
 import { Typography } from "@material-ui/core";
 import useInterval from "@use-it/interval";
-import React, { useState } from "react";
+import React from "react";
 import { useAsync } from "react-async";
 import { RouteComponentProps } from "react-router-dom";
 import { EmbeddedRepresentationSubEntity } from "../../gen/siren";
@@ -10,29 +10,24 @@ import ErrorSnackbar from "../components/ErrorSnackbar";
 import SwapList from "./SwapList/SwapList";
 import Swap from "./SwapPage/Swap";
 
-const getComitResourceFn = async ({ resourcePath, callback }: any) => {
-  return getComitResource(resourcePath).then(data => {
-    callback();
-    return data;
-  });
+const getComitResourceFn = async ({ resourcePath }: any) => {
+  return getComitResource(resourcePath);
 };
 
 function ShowResource({ location }: RouteComponentProps) {
   const resourcePath = location.pathname.replace("/show_resource/", "");
-  const [previousPath, setPreviousPath] = useState("");
 
   const { data: entity, isLoading, error, reload } = useAsync(
     getComitResourceFn,
     {
       resourcePath,
-      callback: () => setPreviousPath(location.pathname),
       watch: location.pathname
     }
   );
 
   useInterval(() => reload(), isLoading ? null : 15000);
 
-  if (isLoading && previousPath !== location.pathname) {
+  if (isLoading) {
     return <CenteredProgress title="Fetching..." />;
   } else if (
     !error &&

--- a/src/pages/ShowResource.tsx
+++ b/src/pages/ShowResource.tsx
@@ -38,68 +38,78 @@ function ShowResource({ location }: RouteComponentProps) {
 
   useInterval(() => reload(), preventReload || isLoading ? null : 15000);
 
-  let resource;
-  if (!axiosError && entity && entity.class && entity.class.includes("swaps")) {
-    resource = (
-      <SwapList
-        swaps={entity.entities as EmbeddedRepresentationSubEntity[]}
-        reload={reload}
-        setPreventReload={setPreventReload}
-      />
-    );
-  } else if (
-    !axiosError &&
-    entity &&
-    entity.class &&
-    entity.class.includes("swap")
-  ) {
-    resource = (
-      <Swap swap={entity} reload={reload} setPreventReload={setPreventReload} />
-    );
-  } else if (axiosError) {
+  function resource() {
     if (
-      axiosError.response &&
-      axiosError.response.status &&
-      Math.floor(axiosError.response.status / 100) !== 2
+      !axiosError &&
+      entity &&
+      entity.class &&
+      entity.class.includes("swaps")
     ) {
-      resource = (
-        <Typography variant="h3" align="center" data-cy="404-typography">
-          404 Resource Not Found
-        </Typography>
+      return (
+        <SwapList
+          swaps={entity.entities as EmbeddedRepresentationSubEntity[]}
+          reload={reload}
+          setPreventReload={setPreventReload}
+        />
       );
-    } else {
-      // Network error
-      resource = (
-        <React.Fragment>
+    } else if (
+      !axiosError &&
+      entity &&
+      entity.class &&
+      entity.class.includes("swap")
+    ) {
+      return (
+        <Swap
+          swap={entity}
+          reload={reload}
+          setPreventReload={setPreventReload}
+        />
+      );
+    } else if (axiosError) {
+      if (
+        axiosError.response &&
+        axiosError.response.status &&
+        Math.floor(axiosError.response.status / 100) !== 2
+      ) {
+        return (
           <Typography variant="h3" align="center" data-cy="404-typography">
             404 Resource Not Found
           </Typography>
+        );
+      } else {
+        // Network error
+        return (
+          <React.Fragment>
+            <Typography variant="h3" align="center" data-cy="404-typography">
+              404 Resource Not Found
+            </Typography>
+            <ErrorSnackbar
+              message="Failed to fetch resource. Is your COMIT node running?"
+              open={true}
+            />
+          </React.Fragment>
+        );
+      }
+    } else if (!entity) {
+      return;
+    } else {
+      return (
+        <React.Fragment>
+          <Typography variant="h3" align="center" data-cy="bad-json-typography">
+            Bad JSON
+          </Typography>
           <ErrorSnackbar
-            message="Failed to fetch resource. Is your COMIT node running?"
+            message="Could not handle comit node's response. Are your comit-i and comit node versions compatible?"
             open={true}
           />
         </React.Fragment>
       );
     }
-  } else if (!entity) {
-    resource = null;
-  } else {
-    resource = (
-      <React.Fragment>
-        <Typography variant="h3" align="center" data-cy="bad-json-typography">
-          Bad JSON
-        </Typography>
-        <ErrorSnackbar
-          message="Could not handle comit node's response. Are your comit-i and comit node versions compatible?"
-          open={true}
-        />
-      </React.Fragment>
-    );
   }
 
   return (
     <React.Fragment>
-      {resource}
+      {resource()}
       <Snackbar
         open={!axiosError && !preventReload && showLoading}
         onClose={() => setShowLoading(false)}

--- a/src/pages/ShowResource.tsx
+++ b/src/pages/ShowResource.tsx
@@ -28,7 +28,7 @@ function ShowResource({ location }: RouteComponentProps) {
   const axiosError = error as AxiosError;
 
   const [showLoading, setShowLoading] = useState(false);
-  const [preventReload, setPreventReload] = useState(false);
+  const [allowReload, setAllowReload] = useState(true);
 
   useEffect(() => {
     if (isLoading) {
@@ -36,7 +36,7 @@ function ShowResource({ location }: RouteComponentProps) {
     }
   }, [isLoading]);
 
-  useInterval(() => reload(), preventReload || isLoading ? null : 15000);
+  useInterval(() => reload(), allowReload && !isLoading ? 15000 : null);
 
   function resource() {
     if (
@@ -49,7 +49,7 @@ function ShowResource({ location }: RouteComponentProps) {
         <SwapList
           swaps={entity.entities as EmbeddedRepresentationSubEntity[]}
           reload={reload}
-          setPreventReload={setPreventReload}
+          setAllowReload={setAllowReload}
         />
       );
     } else if (
@@ -59,11 +59,7 @@ function ShowResource({ location }: RouteComponentProps) {
       entity.class.includes("swap")
     ) {
       return (
-        <Swap
-          swap={entity}
-          reload={reload}
-          setPreventReload={setPreventReload}
-        />
+        <Swap swap={entity} reload={reload} setAllowReload={setAllowReload} />
       );
     } else if (axiosError) {
       if (
@@ -111,7 +107,7 @@ function ShowResource({ location }: RouteComponentProps) {
     <React.Fragment>
       {resource()}
       <Snackbar
-        open={!axiosError && !preventReload && showLoading}
+        open={!axiosError && !allowReload && showLoading}
         onClose={() => setShowLoading(false)}
         message="Loading"
         icon={CircularProgress}

--- a/src/pages/SwapList/SwapList.tsx
+++ b/src/pages/SwapList/SwapList.tsx
@@ -13,10 +13,10 @@ import SwapRow from "./SwapRow/SwapRow";
 interface SwapListProps {
   swaps: EmbeddedRepresentationSubEntity[];
   reload: () => void;
-  setPreventReload: (arg: boolean) => void;
+  setAllowReload: (arg: boolean) => void;
 }
 
-function SwapList({ swaps, reload, setPreventReload }: SwapListProps) {
+function SwapList({ swaps, reload, setAllowReload }: SwapListProps) {
   const hasSwaps = swaps.length !== 0;
 
   return (
@@ -41,7 +41,7 @@ function SwapList({ swaps, reload, setPreventReload }: SwapListProps) {
               key={index}
               swap={swap}
               reload={reload}
-              setPreventReload={setPreventReload}
+              setAllowReload={setAllowReload}
             />
           ))}
         {!hasSwaps && <EmptySwapListTableRow />}

--- a/src/pages/SwapList/SwapList.tsx
+++ b/src/pages/SwapList/SwapList.tsx
@@ -13,9 +13,10 @@ import SwapRow from "./SwapRow/SwapRow";
 interface SwapListProps {
   swaps: EmbeddedRepresentationSubEntity[];
   reload: () => void;
+  setPreventReload: (arg: boolean) => void;
 }
 
-function SwapList({ swaps, reload }: SwapListProps) {
+function SwapList({ swaps, reload, setPreventReload }: SwapListProps) {
   const hasSwaps = swaps.length !== 0;
 
   return (
@@ -36,7 +37,12 @@ function SwapList({ swaps, reload }: SwapListProps) {
       <TableBody>
         {hasSwaps &&
           swaps.map((swap, index) => (
-            <SwapRow key={index} swap={swap} reload={reload} />
+            <SwapRow
+              key={index}
+              swap={swap}
+              reload={reload}
+              setPreventReload={setPreventReload}
+            />
           ))}
         {!hasSwaps && <EmptySwapListTableRow />}
       </TableBody>

--- a/src/pages/SwapList/SwapRow/SwapRow.tsx
+++ b/src/pages/SwapList/SwapRow/SwapRow.tsx
@@ -42,9 +42,10 @@ const useStyles = makeStyles(() => ({
 interface SwapRowProps extends RouteComponentProps {
   swap: EmbeddedRepresentationSubEntity;
   reload: () => void;
+  setPreventReload: (arg: boolean) => void;
 }
 
-function SwapRow({ swap, history, reload }: SwapRowProps) {
+function SwapRow({ swap, history, reload, setPreventReload }: SwapRowProps) {
   const [
     {
       state: {
@@ -57,7 +58,7 @@ function SwapRow({ swap, history, reload }: SwapRowProps) {
     dispatch
   ] = useReducer(reducer, initialState);
 
-  useSideEffect(reload, dispatch, sideEffect);
+  useSideEffect(reload, setPreventReload, dispatch, sideEffect);
 
   const classes = useStyles();
 

--- a/src/pages/SwapList/SwapRow/SwapRow.tsx
+++ b/src/pages/SwapList/SwapRow/SwapRow.tsx
@@ -19,6 +19,7 @@ import {
   initialState,
   reducer
 } from "../../actions/reducer";
+import useAllowReload from "../../actions/useAllowReload";
 import useSideEffect from "../../actions/useSideEffect";
 import LedgerActionDialogBody from "../LedgerActionDialogBody";
 import SirenActionParametersDialogBody from "../SirenActionParametersDialogBody";
@@ -58,7 +59,11 @@ function SwapRow({ swap, history, reload, setAllowReload }: SwapRowProps) {
     dispatch
   ] = useReducer(reducer, initialState);
 
-  useSideEffect(reload, setAllowReload, dispatch, sideEffect);
+  useSideEffect(reload, dispatch, sideEffect);
+  useAllowReload(
+    !!activeLedgerActionDialog || !!activeSirenParameterDialog,
+    setAllowReload
+  );
 
   const classes = useStyles();
 

--- a/src/pages/SwapList/SwapRow/SwapRow.tsx
+++ b/src/pages/SwapList/SwapRow/SwapRow.tsx
@@ -42,10 +42,10 @@ const useStyles = makeStyles(() => ({
 interface SwapRowProps extends RouteComponentProps {
   swap: EmbeddedRepresentationSubEntity;
   reload: () => void;
-  setPreventReload: (arg: boolean) => void;
+  setAllowReload: (arg: boolean) => void;
 }
 
-function SwapRow({ swap, history, reload, setPreventReload }: SwapRowProps) {
+function SwapRow({ swap, history, reload, setAllowReload }: SwapRowProps) {
   const [
     {
       state: {
@@ -58,7 +58,7 @@ function SwapRow({ swap, history, reload, setPreventReload }: SwapRowProps) {
     dispatch
   ] = useReducer(reducer, initialState);
 
-  useSideEffect(reload, setPreventReload, dispatch, sideEffect);
+  useSideEffect(reload, setAllowReload, dispatch, sideEffect);
 
   const classes = useStyles();
 

--- a/src/pages/SwapPage/Swap.tsx
+++ b/src/pages/SwapPage/Swap.tsx
@@ -34,9 +34,10 @@ import SwapMetaDataCard from "./SwapMetaDataCard";
 interface SwapProps {
   swap: Entity;
   reload: () => void;
+  setPreventReload: (arg: boolean) => void;
 }
 
-function Swap({ swap, reload }: SwapProps) {
+function Swap({ swap, reload, setPreventReload }: SwapProps) {
   const properties = swap.properties as Properties & AdditionalProperties;
   const [alphaLedger, betaLedger] = [
     properties.parameters.alpha_ledger,
@@ -94,7 +95,7 @@ function Swap({ swap, reload }: SwapProps) {
     dispatch
   ] = useReducer(reducer, initialState);
 
-  useSideEffect(reload, dispatch, sideEffect);
+  useSideEffect(reload, setPreventReload, dispatch, sideEffect);
 
   const isActionInProgress =
     actionExecutionStatus === ActionExecutionStatus.InProgress;

--- a/src/pages/SwapPage/Swap.tsx
+++ b/src/pages/SwapPage/Swap.tsx
@@ -34,10 +34,10 @@ import SwapMetaDataCard from "./SwapMetaDataCard";
 interface SwapProps {
   swap: Entity;
   reload: () => void;
-  setPreventReload: (arg: boolean) => void;
+  setAllowReload: (arg: boolean) => void;
 }
 
-function Swap({ swap, reload, setPreventReload }: SwapProps) {
+function Swap({ swap, reload, setAllowReload }: SwapProps) {
   const properties = swap.properties as Properties & AdditionalProperties;
   const [alphaLedger, betaLedger] = [
     properties.parameters.alpha_ledger,
@@ -95,7 +95,7 @@ function Swap({ swap, reload, setPreventReload }: SwapProps) {
     dispatch
   ] = useReducer(reducer, initialState);
 
-  useSideEffect(reload, setPreventReload, dispatch, sideEffect);
+  useSideEffect(reload, setAllowReload, dispatch, sideEffect);
 
   const isActionInProgress =
     actionExecutionStatus === ActionExecutionStatus.InProgress;

--- a/src/pages/SwapPage/Swap.tsx
+++ b/src/pages/SwapPage/Swap.tsx
@@ -23,6 +23,7 @@ import {
   initialState,
   reducer
 } from "../actions/reducer";
+import useAllowReload from "../actions/useAllowReload";
 import useSideEffect from "../actions/useSideEffect";
 import LedgerActionDialogBody from "../SwapList/LedgerActionDialogBody";
 import SirenActionParametersDialogBody from "../SwapList/SirenActionParametersDialogBody";
@@ -95,7 +96,11 @@ function Swap({ swap, reload, setAllowReload }: SwapProps) {
     dispatch
   ] = useReducer(reducer, initialState);
 
-  useSideEffect(reload, setAllowReload, dispatch, sideEffect);
+  useSideEffect(reload, dispatch, sideEffect);
+  useAllowReload(
+    !!activeLedgerActionDialog || !!activeSirenParameterDialog,
+    setAllowReload
+  );
 
   const isActionInProgress =
     actionExecutionStatus === ActionExecutionStatus.InProgress;

--- a/src/pages/actions/events.ts
+++ b/src/pages/actions/events.ts
@@ -32,6 +32,9 @@ export type ReducerEvent =
       payload: {
         error: any;
       };
+    }
+  | {
+      type: "resetState";
     };
 
 export function sirenParameterDialogSubmitted(
@@ -83,5 +86,11 @@ export function closeSirenParametersDialog(): ReducerEvent {
 export function closeLedgerActionDialog(): ReducerEvent {
   return {
     type: "closeLedgerActionDialog"
+  };
+}
+
+export function resetState(): ReducerEvent {
+  return {
+    type: "resetState"
   };
 }

--- a/src/pages/actions/reducer.spec.ts
+++ b/src/pages/actions/reducer.spec.ts
@@ -48,7 +48,7 @@ describe("SwapRowReducer", () => {
       href: "/foo/bar"
     };
 
-    const { state, sideEffect } = reducer(
+    const { state } = reducer(
       initialState,
       actionButtonClicked(actionWithField)
     );
@@ -56,7 +56,6 @@ describe("SwapRowReducer", () => {
     expect(state).toStrictEqual({
       activeSirenParameterDialog: actionWithField
     });
-    expect(sideEffect).toBeUndefined();
   });
 
   it("should trigger action if parameters dialog is submitted", () => {

--- a/src/pages/actions/reducer.ts
+++ b/src/pages/actions/reducer.ts
@@ -19,12 +19,6 @@ export type SideEffect =
     }
   | {
       type: "reloadData";
-    }
-  | {
-      type: "allowReload";
-    }
-  | {
-      type: "preventReload";
     };
 
 interface State {
@@ -52,9 +46,6 @@ export function reducer(
         return {
           state: {
             activeSirenParameterDialog: action
-          },
-          sideEffect: {
-            type: "preventReload"
           }
         };
       } else {
@@ -134,14 +125,9 @@ export function reducer(
         }
       };
     }
-    case "closeSirenParametersDialog": {
-      return {
-        state: {},
-        sideEffect: {
-          type: "allowReload"
-        }
-      };
-    }
+    case "closeSirenParametersDialog":
+    case "resetState":
+      return initialState;
   }
 
   return { state };

--- a/src/pages/actions/reducer.ts
+++ b/src/pages/actions/reducer.ts
@@ -19,6 +19,12 @@ export type SideEffect =
     }
   | {
       type: "reloadData";
+    }
+  | {
+      type: "allowReload";
+    }
+  | {
+      type: "preventReload";
     };
 
 interface State {
@@ -46,6 +52,9 @@ export function reducer(
         return {
           state: {
             activeSirenParameterDialog: action
+          },
+          sideEffect: {
+            type: "preventReload"
           }
         };
       } else {
@@ -125,8 +134,14 @@ export function reducer(
         }
       };
     }
-    case "closeSirenParametersDialog":
-      return initialState;
+    case "closeSirenParametersDialog": {
+      return {
+        state: {},
+        sideEffect: {
+          type: "allowReload"
+        }
+      };
+    }
   }
 
   return { state };

--- a/src/pages/actions/useAllowReload.tsx
+++ b/src/pages/actions/useAllowReload.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+
+export default function useAllowReload(
+  condition: boolean,
+  setAllowReload: (arg: boolean) => void
+) {
+  useEffect(() => {
+    condition ? setAllowReload(false) : setAllowReload(true);
+  }, [condition, setAllowReload]);
+}

--- a/src/pages/actions/useSideEffect.tsx
+++ b/src/pages/actions/useSideEffect.tsx
@@ -5,6 +5,7 @@ import { SideEffect } from "./reducer";
 
 export default function useSideEffect(
   reload: () => void,
+  setPreventReload: (arg: boolean) => void,
   dispatch: React.Dispatch<ReducerEvent>,
   sideEffect: SideEffect | undefined
 ) {
@@ -15,16 +16,26 @@ export default function useSideEffect(
 
     switch (sideEffect.type) {
       case "reloadData": {
+        setPreventReload(false);
         reload();
         return;
       }
       case "executeAction": {
+        setPreventReload(true);
         executeAction(sideEffect.payload.action, sideEffect.payload.data).then(
           response => dispatch(actionSuccessful(response)),
           error => dispatch(actionFailed(error))
         );
         return;
       }
+      case "allowReload": {
+        setPreventReload(false);
+        return;
+      }
+      case "preventReload": {
+        setPreventReload(true);
+        return;
+      }
     }
-  }, [sideEffect, reload, dispatch]);
+  }, [sideEffect, reload, setPreventReload, dispatch]);
 }

--- a/src/pages/actions/useSideEffect.tsx
+++ b/src/pages/actions/useSideEffect.tsx
@@ -5,7 +5,7 @@ import { SideEffect } from "./reducer";
 
 export default function useSideEffect(
   reload: () => void,
-  setPreventReload: (arg: boolean) => void,
+  setAllowReload: (arg: boolean) => void,
   dispatch: React.Dispatch<ReducerEvent>,
   sideEffect: SideEffect | undefined
 ) {
@@ -16,12 +16,12 @@ export default function useSideEffect(
 
     switch (sideEffect.type) {
       case "reloadData": {
-        setPreventReload(false);
+        setAllowReload(true);
         reload();
         return;
       }
       case "executeAction": {
-        setPreventReload(true);
+        setAllowReload(false);
         executeAction(sideEffect.payload.action, sideEffect.payload.data).then(
           response => dispatch(actionSuccessful(response)),
           error => dispatch(actionFailed(error))
@@ -29,13 +29,13 @@ export default function useSideEffect(
         return;
       }
       case "allowReload": {
-        setPreventReload(false);
+        setAllowReload(true);
         return;
       }
       case "preventReload": {
-        setPreventReload(true);
+        setAllowReload(false);
         return;
       }
     }
-  }, [sideEffect, reload, setPreventReload, dispatch]);
+  }, [sideEffect, reload, setAllowReload, dispatch]);
 }

--- a/src/pages/actions/useSideEffect.tsx
+++ b/src/pages/actions/useSideEffect.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect } from "react";
 import executeAction from "../../api/executeAction";
-import { actionFailed, actionSuccessful, ReducerEvent } from "./events";
+import {
+  actionFailed,
+  actionSuccessful,
+  ReducerEvent,
+  resetState
+} from "./events";
 import { SideEffect } from "./reducer";
 
 export default function useSideEffect(
   reload: () => void,
-  setAllowReload: (arg: boolean) => void,
   dispatch: React.Dispatch<ReducerEvent>,
   sideEffect: SideEffect | undefined
 ) {
@@ -16,26 +20,16 @@ export default function useSideEffect(
 
     switch (sideEffect.type) {
       case "reloadData": {
-        setAllowReload(true);
         reload();
-        return;
+        return dispatch(resetState());
       }
       case "executeAction": {
-        setAllowReload(false);
         executeAction(sideEffect.payload.action, sideEffect.payload.data).then(
           response => dispatch(actionSuccessful(response)),
           error => dispatch(actionFailed(error))
         );
         return;
       }
-      case "allowReload": {
-        setAllowReload(true);
-        return;
-      }
-      case "preventReload": {
-        setAllowReload(false);
-        return;
-      }
     }
-  }, [sideEffect, reload, setAllowReload, dispatch]);
+  }, [sideEffect, reload, dispatch]);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2664,6 +2664,11 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+"@use-it/interval@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@use-it/interval/-/interval-0.1.3.tgz#5d1096b2295d7a5dda8e8022f3abb5f9d9ef27f8"
+  integrity sha512-chshdtDZTFoWA9aszBz1Cc04Ca9NBD2JTi/GMjdJ+HGm4q7Vy1v71+2mm22r7Kfb2nYW+lTRsPcEHdB/VFVHsQ==
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"


### PR DESCRIPTION
Resolves #83.

Also fixes a bug that could cause an infinite loop of reloading a resource. We were not cleaning up the state (in particular the `sideEffect`) after reloading the data, which meant that if re-rendered the component would still have `sideEffect` set to `reloadData`, which would trigger another reload etc. Maybe @thomaseizinger can have a look at the proposed solution included (among other things) in the last commit once he's back :wink: 