### PR TITLE
Clarify which assets are being sold/bought

### DIFF
--- a/src/pages/SwapList/SwapList.tsx
+++ b/src/pages/SwapList/SwapList.tsx
@@ -25,8 +25,8 @@ function SwapList({ swaps, reload, setAllowReload }: SwapListProps) {
         <TableRow>
           <TableCell component="th">Status</TableCell>
           <TableCell component="th">ID</TableCell>
-          <TableCell component="th">Alpha Asset</TableCell>
-          <TableCell component="th">Beta Asset</TableCell>
+          <TableCell component="th">Buy</TableCell>
+          <TableCell component="th">Sell</TableCell>
           <TableCell component="th">Protocol</TableCell>
           <TableCell component="th">Role</TableCell>
           <TableCell component="th">Actions</TableCell>

--- a/src/pages/SwapList/SwapList.tsx
+++ b/src/pages/SwapList/SwapList.tsx
@@ -25,9 +25,7 @@ function SwapList({ swaps, reload, setAllowReload }: SwapListProps) {
         <TableRow>
           <TableCell component="th">Status</TableCell>
           <TableCell component="th">ID</TableCell>
-          <TableCell component="th">Alpha Ledger</TableCell>
           <TableCell component="th">Alpha Asset</TableCell>
-          <TableCell component="th">Beta Ledger</TableCell>
           <TableCell component="th">Beta Asset</TableCell>
           <TableCell component="th">Protocol</TableCell>
           <TableCell component="th">Role</TableCell>

--- a/src/pages/SwapList/SwapRow/SwapRow.tsx
+++ b/src/pages/SwapList/SwapRow/SwapRow.tsx
@@ -96,11 +96,9 @@ function SwapRow({ swap, history, reload, setAllowReload }: SwapRowProps) {
         <TableCell>
           <SwapId id={properties.id} />
         </TableCell>
-        <TableCell>{properties.parameters.alpha_ledger.name}</TableCell>
         <TableCell>
           <AssetCell asset={properties.parameters.alpha_asset} />
         </TableCell>
-        <TableCell>{properties.parameters.beta_ledger.name}</TableCell>
         <TableCell>
           <AssetCell asset={properties.parameters.beta_asset} />
         </TableCell>

--- a/src/pages/SwapList/SwapRow/SwapRow.tsx
+++ b/src/pages/SwapList/SwapRow/SwapRow.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from "@material-ui/styles";
 import React, { useReducer } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { EmbeddedRepresentationSubEntity } from "../../../../gen/siren";
-import { Asset, Properties } from "../../../api/swapTypes";
+import { Asset, Properties, Role } from "../../../api/swapTypes";
 import { mainUnitSymbol, toMainUnit } from "../../../api/unit";
 import ActionButton from "../../../components/ActionButton";
 import Dialog from "../../../components/Dialog";
@@ -80,6 +80,13 @@ function SwapRow({ swap, history, reload, setAllowReload }: SwapRowProps) {
     link.rel.includes("human-protocol-spec")
   );
 
+  const assets = [
+    properties.parameters.alpha_asset,
+    properties.parameters.beta_asset
+  ];
+  const [sellAsset, buyAsset] =
+    properties.role === Role.Alice ? assets : assets.reverse();
+
   return (
     <React.Fragment key={swapLink.href}>
       <TableRow
@@ -97,10 +104,10 @@ function SwapRow({ swap, history, reload, setAllowReload }: SwapRowProps) {
           <SwapId id={properties.id} />
         </TableCell>
         <TableCell>
-          <AssetCell asset={properties.parameters.alpha_asset} />
+          <AssetCell asset={buyAsset} />
         </TableCell>
         <TableCell>
-          <AssetCell asset={properties.parameters.beta_asset} />
+          <AssetCell asset={sellAsset} />
         </TableCell>
         <TableCell>
           {protocolSpecLink ? (

--- a/src/pages/SwapList/SwapRow/SwapRow.tsx
+++ b/src/pages/SwapList/SwapRow/SwapRow.tsx
@@ -1,9 +1,14 @@
-import { CircularProgress, TableCell, TableRow } from "@material-ui/core";
+import {
+  CircularProgress,
+  TableCell,
+  TableRow,
+  Tooltip
+} from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import React, { useReducer } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { EmbeddedRepresentationSubEntity } from "../../../../gen/siren";
-import { Asset, Properties, Role } from "../../../api/swapTypes";
+import { Asset, Ledger, Properties, Role } from "../../../api/swapTypes";
 import { mainUnitSymbol, toMainUnit } from "../../../api/unit";
 import ActionButton from "../../../components/ActionButton";
 import Dialog from "../../../components/Dialog";
@@ -25,14 +30,6 @@ import LedgerActionDialogBody from "../LedgerActionDialogBody";
 import SirenActionParametersDialogBody from "../SirenActionParametersDialogBody";
 import SwapStatusIcon from "../SwapStatusIcon";
 import SwapId from "./SwapId";
-
-interface AssetCellProps {
-  asset: Asset;
-}
-
-function AssetCell({ asset }: AssetCellProps) {
-  return <span>{toMainUnit(asset) + " " + mainUnitSymbol(asset)}</span>;
-}
 
 const useStyles = makeStyles(() => ({
   tableRow: {
@@ -87,6 +84,13 @@ function SwapRow({ swap, history, reload, setAllowReload }: SwapRowProps) {
   const [sellAsset, buyAsset] =
     properties.role === Role.Alice ? assets : assets.reverse();
 
+  const ledgers = [
+    properties.parameters.alpha_ledger,
+    properties.parameters.beta_ledger
+  ];
+  const [sellLedger, buyLedger] =
+    properties.role === Role.Alice ? ledgers : ledgers.reverse();
+
   return (
     <React.Fragment key={swapLink.href}>
       <TableRow
@@ -104,10 +108,10 @@ function SwapRow({ swap, history, reload, setAllowReload }: SwapRowProps) {
           <SwapId id={properties.id} />
         </TableCell>
         <TableCell>
-          <AssetCell asset={buyAsset} />
+          <AssetCell asset={buyAsset} ledger={buyLedger} />
         </TableCell>
         <TableCell>
-          <AssetCell asset={sellAsset} />
+          <AssetCell asset={sellAsset} ledger={sellLedger} />
         </TableCell>
         <TableCell>
           {protocolSpecLink ? (
@@ -165,6 +169,19 @@ function SwapRow({ swap, history, reload, setAllowReload }: SwapRowProps) {
         </Dialog>
       )}
     </React.Fragment>
+  );
+}
+
+interface AssetCellProps {
+  asset: Asset;
+  ledger: Ledger;
+}
+
+function AssetCell({ asset, ledger }: AssetCellProps) {
+  return (
+    <Tooltip title={"On " + ledger.name + " " + ledger.network}>
+      <span>{toMainUnit(asset) + " " + mainUnitSymbol(asset)}</span>
+    </Tooltip>
   );
 }
 

--- a/src/pages/SwapList/SwapStatusIcon.tsx
+++ b/src/pages/SwapList/SwapStatusIcon.tsx
@@ -33,37 +33,45 @@ function SwapStatusIcon({ status }: SwapStatusIconProps) {
     case Status.InProgress:
       return (
         <Tooltip title="Swap in progress" placement="bottom-start">
-          <FontAwesomeIcon
-            icon={faSync}
-            className={classes.inProgressIcon}
-            size="lg"
-          />
+          <div>
+            <FontAwesomeIcon
+              icon={faSync}
+              className={classes.inProgressIcon}
+              size="lg"
+            />
+          </div>
         </Tooltip>
       );
     case Status.Swapped:
       return (
         <Tooltip title="Swap completed" placement="bottom-start">
-          <FontAwesomeIcon icon={faCheck} color="green" size="lg" />
+          <div>
+            <FontAwesomeIcon icon={faCheck} color="green" size="lg" />
+          </div>
         </Tooltip>
       );
     case Status.NotSwapped:
       return (
         <Tooltip title="Swap finished unsuccessfully" placement="bottom-start">
-          <FontAwesomeIcon
-            icon={faTimes}
-            className={classes.notSwappedIcon}
-            size="lg"
-          />
+          <div>
+            <FontAwesomeIcon
+              icon={faTimes}
+              className={classes.notSwappedIcon}
+              size="lg"
+            />
+          </div>
         </Tooltip>
       );
     case Status.InternalFailure:
       return (
         <Tooltip title="Internal failure" placement="bottom-start">
-          <FontAwesomeIcon
-            icon={faExclamationCircle}
-            className={classes.internalFailureIcon}
-            size="lg"
-          />
+          <div>
+            <FontAwesomeIcon
+              icon={faExclamationCircle}
+              className={classes.internalFailureIcon}
+              size="lg"
+            />
+          </div>
         </Tooltip>
       );
   }

--- a/src/pages/SwapList/SwapStatusIcon.tsx
+++ b/src/pages/SwapList/SwapStatusIcon.tsx
@@ -32,7 +32,7 @@ function SwapStatusIcon({ status }: SwapStatusIconProps) {
   switch (status) {
     case Status.InProgress:
       return (
-        <Tooltip title="Swap in progress" placement="bottom-start">
+        <Tooltip title="Swap in progress">
           <div>
             <FontAwesomeIcon
               icon={faSync}
@@ -44,7 +44,7 @@ function SwapStatusIcon({ status }: SwapStatusIconProps) {
       );
     case Status.Swapped:
       return (
-        <Tooltip title="Swap completed" placement="bottom-start">
+        <Tooltip title="Swap completed">
           <div>
             <FontAwesomeIcon icon={faCheck} color="green" size="lg" />
           </div>
@@ -52,7 +52,7 @@ function SwapStatusIcon({ status }: SwapStatusIconProps) {
       );
     case Status.NotSwapped:
       return (
-        <Tooltip title="Swap finished unsuccessfully" placement="bottom-start">
+        <Tooltip title="Swap finished unsuccessfully">
           <div>
             <FontAwesomeIcon
               icon={faTimes}
@@ -64,7 +64,7 @@ function SwapStatusIcon({ status }: SwapStatusIconProps) {
       );
     case Status.InternalFailure:
       return (
-        <Tooltip title="Internal failure" placement="bottom-start">
+        <Tooltip title="Internal failure">
           <div>
             <FontAwesomeIcon
               icon={faExclamationCircle}

--- a/src/pages/SwapPage/Swap.tsx
+++ b/src/pages/SwapPage/Swap.tsx
@@ -119,6 +119,7 @@ function Swap({ swap, reload, setAllowReload }: SwapProps) {
               counterparty={properties.counterparty}
               protocol={properties.protocol}
               protocolSpecLink={protocolSpecLink}
+              role={properties.role}
             />
           </Grid>
           <Grid item={true} xs={6}>

--- a/src/pages/SwapPage/Swap.tsx
+++ b/src/pages/SwapPage/Swap.tsx
@@ -84,6 +84,10 @@ function Swap({ swap, reload, setAllowReload }: SwapProps) {
             action.name === "refund"
         );
 
+  const protocolSpecLink = (swap.links || []).find(link =>
+    link.rel.includes("human-protocol-spec")
+  );
+
   const [
     {
       state: {
@@ -113,6 +117,8 @@ function Swap({ swap, reload, setAllowReload }: SwapProps) {
             <SwapMetaDataCard
               swapId={properties.id}
               counterparty={properties.counterparty}
+              protocol={properties.protocol}
+              protocolSpecLink={protocolSpecLink}
             />
           </Grid>
           <Grid item={true} xs={6}>

--- a/src/pages/SwapPage/SwapMetaDataCard.tsx
+++ b/src/pages/SwapPage/SwapMetaDataCard.tsx
@@ -1,18 +1,36 @@
 import { Card, Typography } from "@material-ui/core";
 import CardContent from "@material-ui/core/CardContent";
 import React from "react";
+import { Link } from "../../../gen/siren";
+import { Protocol } from "../../api/swapTypes";
+import ExternalLink from "../../components/ExternalLink";
 
 interface SwapMetaDataCardProps {
   swapId: string;
   counterparty: string;
+  protocol: Protocol;
+  protocolSpecLink: Link | undefined;
 }
 
-function SwapMetaDataCard({ swapId, counterparty }: SwapMetaDataCardProps) {
+function SwapMetaDataCard({
+  swapId,
+  counterparty,
+  protocol,
+  protocolSpecLink
+}: SwapMetaDataCardProps) {
   return (
     <Card data-cy="swap-metadata-card">
       <CardContent>
         <Typography>{`Swap ID: ${swapId}`}</Typography>
         <Typography>{`Trading with: ${counterparty}`}</Typography>
+        <Typography display="inline">Protocol: </Typography>
+        <Typography display="inline">
+          {protocolSpecLink ? (
+            <ExternalLink href={protocolSpecLink.href} text={protocol} />
+          ) : (
+            protocol
+          )}
+        </Typography>
       </CardContent>
     </Card>
   );

--- a/src/pages/SwapPage/SwapMetaDataCard.tsx
+++ b/src/pages/SwapPage/SwapMetaDataCard.tsx
@@ -2,7 +2,7 @@ import { Card, Typography } from "@material-ui/core";
 import CardContent from "@material-ui/core/CardContent";
 import React from "react";
 import { Link } from "../../../gen/siren";
-import { Protocol } from "../../api/swapTypes";
+import { Protocol, Role } from "../../api/swapTypes";
 import ExternalLink from "../../components/ExternalLink";
 
 interface SwapMetaDataCardProps {
@@ -10,13 +10,15 @@ interface SwapMetaDataCardProps {
   counterparty: string;
   protocol: Protocol;
   protocolSpecLink: Link | undefined;
+  role: Role;
 }
 
 function SwapMetaDataCard({
   swapId,
   counterparty,
   protocol,
-  protocolSpecLink
+  protocolSpecLink,
+  role
 }: SwapMetaDataCardProps) {
   return (
     <Card data-cy="swap-metadata-card">
@@ -31,6 +33,7 @@ function SwapMetaDataCard({
             protocol
           )}
         </Typography>
+        <Typography>{`Role: ${role}`}</Typography>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
The swap page already explicitly indicated which asset was being sold and which one was being bought: 

![Jun24::174414](https://user-images.githubusercontent.com/9418575/60032899-d04e2d80-96a7-11e9-9b23-8dc4e388681c.png)

This information has now been added to the swap list too:

![Jun24::174814](https://user-images.githubusercontent.com/9418575/60033121-4488d100-96a8-11e9-9685-84eec4d2b5ff.png)

As you can see, the swap list no longer has columns for `Alpha ledger`, `Beta ledger`, `Alpha asset` and `Beta asset`. These details are relegated to the swap page, though the user can now hover over a `Buy` or `Sell` cell to see on what ledger the asset is hosted on, including network information:

![Jun24::175613](https://user-images.githubusercontent.com/9418575/60033748-72224a00-96a9-11e9-83c5-13d2662d9ff9.gif)

Additionally:

- Fixed the tooltip of swap status icons on the swap list.
- Added role and protocol information to swap page (see first screenshot). 

Resolves #97.