### PR TITLE
Improve usability if MetaMask is disabled

### DIFF
--- a/src/api/getAction.ts
+++ b/src/api/getAction.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 
-export type LedgerAction =
+export type LedgerAction = BitcoinAction | EthereumAction;
+
+export type BitcoinAction =
   | {
       type: "bitcoin-send-amount-to-address";
       payload: { to: string; amount: string; network: string };
@@ -8,7 +10,9 @@ export type LedgerAction =
   | {
       type: "bitcoin-broadcast-signed-transaction";
       payload: { hex: string; network: string; min_median_block_time?: number };
-    }
+    };
+
+export type EthereumAction =
   | {
       type: "ethereum-deploy-contract";
       payload: {

--- a/src/pages/SwapList/LedgerActionDialogBody.tsx
+++ b/src/pages/SwapList/LedgerActionDialogBody.tsx
@@ -148,6 +148,7 @@ function EthereumActionDialogBody({
   actionDoneBefore = false
 }: EthereumActionDialogBodyProps) {
   const { web3 } = useWeb3();
+  const gasLimit = parseInt(action.payload.gas_limit, 16);
 
   function onSuccessMetaMask(transactionId: string) {
     onSuccess(transactionId);
@@ -166,7 +167,6 @@ function EthereumActionDialogBody({
         name: "ether",
         quantity: action.payload.amount
       });
-      const gasLimit = parseInt(action.payload.gas_limit, 16);
       const contract = action.payload.data;
 
       return (
@@ -227,7 +227,6 @@ function EthereumActionDialogBody({
     case "ethereum-call-contract": {
       const address = action.payload.contract_address;
       const data = action.payload.data;
-      const gasLimit = parseInt(action.payload.gas_limit, 16);
 
       const expiry = action.payload.min_block_timestamp;
 

--- a/src/pages/SwapList/LedgerActionDialogBody.tsx
+++ b/src/pages/SwapList/LedgerActionDialogBody.tsx
@@ -149,8 +149,12 @@ function EthereumActionDialogBody({
 }: EthereumActionDialogBodyProps) {
   const { web3 } = useWeb3();
 
-  function onSuccessEthereum(transactionId: string) {
+  function onSuccessMetaMask(transactionId: string) {
     onSuccess(transactionId);
+  }
+
+  function onManualConfirmation() {
+    onSuccess();
   }
 
   switch (action.type) {
@@ -199,13 +203,22 @@ function EthereumActionDialogBody({
             <Button onClick={onClose} variant="contained" color="secondary">
               Cancel
             </Button>
+            {!web3 && (
+              <Button
+                onClick={onManualConfirmation}
+                variant="contained"
+                color="primary"
+              >
+                Confirm
+              </Button>
+            )}
             <Web3SendTransactionButton
               transactionConfig={{
                 data: contract,
                 value: action.payload.amount,
                 gas: gasLimit
               }}
-              onSuccess={onSuccessEthereum}
+              onSuccess={onSuccessMetaMask}
             />
           </DialogActions>
         </React.Fragment>
@@ -251,6 +264,15 @@ function EthereumActionDialogBody({
             <Button onClick={onClose} variant="contained" color="secondary">
               Cancel
             </Button>
+            {!web3 && (
+              <Button
+                onClick={onManualConfirmation}
+                variant="contained"
+                color="primary"
+              >
+                Confirm
+              </Button>
+            )}
             <Web3SendTransactionButton
               minTimestamp={expiry}
               transactionConfig={{
@@ -258,7 +280,7 @@ function EthereumActionDialogBody({
                 data,
                 gas: gasLimit
               }}
-              onSuccess={onSuccessEthereum}
+              onSuccess={onSuccessMetaMask}
             />
           </DialogActions>
         </React.Fragment>

--- a/src/pages/SwapList/LedgerActionDialogBody.tsx
+++ b/src/pages/SwapList/LedgerActionDialogBody.tsx
@@ -32,6 +32,7 @@ function LedgerActionDialogBody({
       );
     }
     case "bitcoin-broadcast-signed-transaction": {
+      const transaction = action.payload.hex;
       const expiry = action.payload.min_median_block_time;
       const whenReadyMessage = !expiry
         ? "now"
@@ -51,14 +52,11 @@ function LedgerActionDialogBody({
                 wordWrap: "break-word"
               }}
             >
-              {action.payload.hex}
+              {transaction}
             </Typography>
           </DialogContent>
           <DialogActions>
-            <CopyToClipboardButton
-              content={action.payload.hex}
-              name="transaction"
-            />
+            <CopyToClipboardButton content={transaction} name="transaction" />
             <Button onClick={onClose} color="secondary">
               Close
             </Button>
@@ -71,6 +69,7 @@ function LedgerActionDialogBody({
         name: "bitcoin",
         quantity: action.payload.amount
       });
+      const address = action.payload.to;
 
       return (
         <React.Fragment>
@@ -80,11 +79,11 @@ function LedgerActionDialogBody({
               Please send <b>{amount}</b> BTC to the following{" "}
               <b>{action.payload.network}</b> address:
             </Typography>
-            {action.payload.to}
+            {address}
           </DialogContent>
           <DialogActions>
             <CopyToClipboardButton content={amount} name="amount" />
-            <CopyToClipboardButton content={action.payload.to} name="address" />
+            <CopyToClipboardButton content={address} name="address" />
             <Button onClick={onClose} color="secondary">
               Close
             </Button>

--- a/src/pages/SwapList/__snapshots__/LedgerActionDialogBody.spec.tsx.snap
+++ b/src/pages/SwapList/__snapshots__/LedgerActionDialogBody.spec.tsx.snap
@@ -528,6 +528,32 @@ Array [
         className="MuiTouchRipple-root"
       />
     </button>
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-containedPrimary MuiButton-contained"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Confirm
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
     <span
       aria-describedby={null}
       className=""
@@ -903,6 +929,32 @@ Array [
         className="MuiButton-label"
       >
         Cancel
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-containedPrimary MuiButton-contained"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Confirm
       </span>
       <span
         className="MuiTouchRipple-root"

--- a/src/pages/SwapList/__snapshots__/LedgerActionDialogBody.spec.tsx.snap
+++ b/src/pages/SwapList/__snapshots__/LedgerActionDialogBody.spec.tsx.snap
@@ -283,11 +283,17 @@ Array [
       <b>
         0x1189128ff5573f6282dbbf1557ed839dab277aeb
       </b>
-       on the Ethereum 
+       on the Ethereum
+       
       <b>
         regtest
       </b>
-       network with this data:
+       network using a gas limit of
+       
+      <b>
+        100000
+      </b>
+       wei with this data:
     </p>
     <p
       className="MuiTypography-root MuiTypography-body1"
@@ -299,6 +305,139 @@ Array [
     >
       0x
     </p>
+  </div>,
+  <div
+    className="MuiDialogActions-root MuiDialogActions-spacing"
+  >
+    <button
+      aria-describedby={null}
+      className="MuiButtonBase-root MuiButton-root MuiButton-textPrimary MuiButton-text"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      title={null}
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+          />
+        </svg>
+        Copy address to clipboard
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+    <button
+      aria-describedby={null}
+      className="MuiButtonBase-root MuiButton-root MuiButton-textPrimary MuiButton-text"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      title={null}
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+          />
+        </svg>
+        Copy data to clipboard
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+    <button
+      aria-describedby={null}
+      className="MuiButtonBase-root MuiButton-root MuiButton-textPrimary MuiButton-text"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      title={null}
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+          />
+        </svg>
+        Copy gas limit to clipboard
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
   </div>,
   <div
     className="MuiDialogActions-root MuiDialogActions-spacing"
@@ -524,11 +663,17 @@ Array [
       <b>
         regtest
       </b>
-       network with 
+       network with
+       
       <b>
         111.111111111111111111
       </b>
-       ETH:
+       ETH using a gas limit of 
+      <b>
+        122000
+      </b>
+       
+      wei:
     </p>
     <p
       className="MuiTypography-root MuiTypography-body1"
@@ -540,6 +685,139 @@ Array [
     >
       0x6100dc61000f6000396100dc6000f336156051576020361415605c57602060006000376020602160206000600060026048f17f57dd4f2557f4b1d593554932a25ce4180c033a8e370632f351ff33f5a5f1973e602151141660625760006000f35b42635cd5aa6a10609f575b60006000f35b7fb8cac300e37f03ad332e581dea21b2f0b84eaaadc184a295fef71e81f44a741360206000a173493a5a0eafdeae28f430f74ac5031b3ee37b6a6dff5b7f5d26862916391bf49478b2f5103b0720a842b45ef145a268f2cd1fb2aed5517860006000a173493a5a0eafdeae28f430f74ac5031b3ee37b6a6dff
     </p>
+  </div>,
+  <div
+    className="MuiDialogActions-root MuiDialogActions-spacing"
+  >
+    <button
+      aria-describedby={null}
+      className="MuiButtonBase-root MuiButton-root MuiButton-textPrimary MuiButton-text"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      title={null}
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+          />
+        </svg>
+        Copy amount to clipboard
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+    <button
+      aria-describedby={null}
+      className="MuiButtonBase-root MuiButton-root MuiButton-textPrimary MuiButton-text"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      title={null}
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+          />
+        </svg>
+        Copy contract code to clipboard
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+    <button
+      aria-describedby={null}
+      className="MuiButtonBase-root MuiButton-root MuiButton-textPrimary MuiButton-text"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      title={null}
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+          />
+        </svg>
+        Copy gas limit to clipboard
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
   </div>,
   <div
     className="MuiDialogActions-root MuiDialogActions-spacing"


### PR DESCRIPTION
Ethereum actions can now be performed more easily when MetaMask is disabled, by providing copy-to-clipboard buttons and allowing manual confirmation:

![Jun26::182704](https://user-images.githubusercontent.com/9418575/60197790-6ddc6500-9840-11e9-9bfa-a96a0ebd91e7.png)

![Jun26::182742](https://user-images.githubusercontent.com/9418575/60197791-6ddc6500-9840-11e9-8097-106641811226.png)

The manual confirmation feature behaves the same way as with Bitcoin actions:

![Jun26::192256](https://user-images.githubusercontent.com/9418575/60201202-088c7200-9848-11e9-86b6-80e42bc0f4f5.gif)

The swap page allows the user to repeat an action if they so desire, but the swap page doesn't display this option.

When MetaMask is enabled, the dialog looks exactly the same as before:

![Jun26::192956](https://user-images.githubusercontent.com/9418575/60201606-f2cb7c80-9848-11e9-80e9-c25404213126.png)

Resolves #102.