### PR TITLE
Actually disable automatic reload when an action dialog is open

### DIFF
--- a/src/pages/actions/useAllowReload.tsx
+++ b/src/pages/actions/useAllowReload.tsx
@@ -8,6 +8,6 @@ export default function useAllowReload(
   setAllowReload: (arg: boolean) => void
 ) {
   useEffect(() => {
-    setAllowReload(!!activeLedgerActionDialog || !!activeSirenParameterDialog);
+    setAllowReload(!activeLedgerActionDialog && !activeSirenParameterDialog);
   }, [activeLedgerActionDialog, activeSirenParameterDialog, setAllowReload]);
 }


### PR DESCRIPTION
I introduced this silly bug. The desired effect is to disable the automatic reload of resources when any action dialog is open.